### PR TITLE
Fix section titles

### DIFF
--- a/_documentation/papers_historical-a.md
+++ b/_documentation/papers_historical-a.md
@@ -1,4 +1,5 @@
 ---
+title:      ""
 order:      200
 category:   Historical Papers
 ---

--- a/_documentation/papers_historical-b.md
+++ b/_documentation/papers_historical-b.md
@@ -1,4 +1,5 @@
 ---
+title:      ""
 order:      200
 category:   Historical Papers
 ---

--- a/_downloads/history_intro1.md
+++ b/_downloads/history_intro1.md
@@ -1,4 +1,5 @@
 ---
+title:    ""
 order:    50
 cols:     6
 category: History

--- a/_downloads/history_intro2.md
+++ b/_downloads/history_intro2.md
@@ -1,4 +1,5 @@
 ---
+title:    ""
 order:    50
 cols:     6
 category: History

--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -12,8 +12,9 @@ layout: compress
 
     <div class="container">
       <div class="section">
-        <h1 class="section-heading"><span>{{ page.section.title }}</span></h1>
-
+        {% if post.section.title %}
+          <h1 class="section-heading"><span>{{ page.section.title }}</span></h1>
+	{% endif %}
         {% if page.head %}
         <div class="section-head text-center">
           {{ page.head }}


### PR DESCRIPTION
Through a recent update (I guess), titles of sections without explicitly set titles are now auto-generated from the corresponding filename. This is not really what we want to these changes should remove that behavior again.