### PR TITLE
Minor Improvements to the Terse Guide

### DIFF
--- a/_pages/terse_guide.md
+++ b/_pages/terse_guide.md
@@ -230,10 +230,9 @@ x := 15 storeStringBase: 16.
 - Value is last expression evaluated unless explicit return
 - Blocks may be nested
 - Specification `[ arguments | | localvars | expressions ]`
-- Squeak does not currently support localvars in blocks
 - Max of three arguments allowed
 - `^` expression terminates block & method (exits all nested blocks)
-- Blocks intended for long term storage should not contain `^`
+- Blocks intended for long term storage must not contain `^`, as they can not return to the sender context
 
 {% highlight smalltalk %}
 | x y z |


### PR DESCRIPTION
Removes the note in the terse guide that claims that local variables would not work in BlockClosures and changed the wording with regard to non-local returns in BlockClosures