### PR TITLE
Removes the news button from the start page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,6 @@ download_link_all: https://files.squeak.org/6.0/Squeak6.0-22104-64bit/Squeak6.0-
 release_notes_link: https://raw.githubusercontent.com/squeak-smalltalk/squeak-app/squeak-trunk/release-notes/6.0
 
 sub_button_group:
-  - title:  News
-    href:   https://news.squeak.org/
-    icon:   newspaper-o
 
   - title:  Bugs
     href:   https://bugs.squeak.org/


### PR DESCRIPTION
I think the lack of activity on the news site does not reflect the progress of Squeak well. As it is unlikely that someone steps up to fill the news site anytime soon, I propose to remove it from the start page for now. 