### PR TITLE
Improve page metadata for title and description (used in search results and social previews)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ collections:
     sort_by: order
     visible-sm: <i class="fa fa-book"></i>
     mobile-title: Docs
+    description: Resources for getting started with Squeak.
   development:
     title: Development
     sort_by: order

--- a/_downloads/_head.md
+++ b/_downloads/_head.md
@@ -1,2 +1,5 @@
+---
+description: Download Squeak images, VMs, and related files from files.squeak.org.
+---
 Find more on
 **[files.squeak.org](https://files.squeak.org/){:target="_blank"}**.

--- a/_pages/board.md
+++ b/_pages/board.md
@@ -2,6 +2,7 @@
 layout:     default
 title:      Squeak Oversight Board
 permalink:  /board/
+description: The Squeak Oversight Board coordinates the community’s open-source development of its versatile Smalltalk environment.
 ---
 {::options parse_block_html="true" /}
 <div class="row">

--- a/_pages/terse_guide.md
+++ b/_pages/terse_guide.md
@@ -1,7 +1,8 @@
 ---
-layout:     default
-title:      "Terse Guide to Squeak"
-permalink:  /documentation/terse_guide/
+layout:      default
+title:       "Terse Guide to Squeak"
+permalink:   /documentation/terse_guide/
+description: A concise overview of Squeak programming concepts.
 ---
 
 # Introduction

--- a/_plugins/page_metadata.rb
+++ b/_plugins/page_metadata.rb
@@ -1,0 +1,106 @@
+require 'cgi'
+
+module Jekyll
+  module DescriptionSource
+    module_function
+
+    RELEASE_NOTES_MARKER = /\A\*{3,}.*\*{3,}\z/  # redundant header in release notes
+
+    def plain_text(html)
+      CGI.unescapeHTML(html.to_s.gsub(/<[^>]+>/, ' '))
+        .gsub(/\s+/, ' ')
+        .gsub(/\s+([,.;:!?])/, '\1')
+        .strip
+    end
+
+    def normalized_text(text)
+      plain_text(text).downcase.gsub(/[^a-z0-9]+/, ' ').strip
+    end
+
+    def paragraph_texts(html)
+      html.to_s
+        .scan(%r{<p\b[^>]*>(.*?)</p>}mi)
+        .flatten
+        .map { |paragraph| plain_text(paragraph) }
+        .reject(&:empty?)
+    end
+
+    def meaningful_paragraph?(paragraph, normalized_title)
+      normalized = normalized_text(paragraph)
+
+      return false if normalized.empty?
+      return false if !normalized_title.empty? && normalized == normalized_title
+      return false if paragraph.match?(RELEASE_NOTES_MARKER)
+
+      true
+    end
+
+    def first_meaningful_paragraph(html, title: nil)
+      normalized_title = normalized_text(title)
+
+      paragraph_texts(html).find do |paragraph|
+        meaningful_paragraph?(paragraph, normalized_title)
+      end
+    end
+
+    def first_front_page_item_description(section)
+      item = section&.docs
+        &.select { |doc| doc.data['front-page'] }
+        &.min_by { |doc| doc.data['order'].to_i }
+
+      plain_text(item.content) if item
+    end
+
+    def section_description(doc)
+      section_config = doc.site.config.dig('collections', doc.data['section_label'].to_s) || {}
+
+      section_config['description'] ||
+        first_meaningful_paragraph(doc.data['head'], title: doc.data['title']) ||
+        first_front_page_item_description(doc.data['section'])
+    end
+
+    def description(doc)
+      return if doc.data['description']
+
+      if doc.data['section_label']
+        description = section_description(doc)
+        return description if description
+      end
+
+      first_meaningful_paragraph(doc.output, title: doc.data['title'])
+    end
+  end
+
+  # :post_convert is only available in newer Jekyll versions :(
+  Hooks.register [:pages, :documents], :post_render do |doc|
+    next unless doc.output_ext == '.html'
+
+    if doc.data['section_fallback_title']
+      section_config =
+        doc.site.config.dig('collections', doc.data['section_label'].to_s) || {}
+
+      og_title = "#{doc.site.config['title']} | #{section_config['title']}"
+      escaped_title = CGI.escapeHTML(og_title)
+
+      doc.output = doc.output.sub(
+        /<meta property="og:title" content="[^"]*" \/>/,
+        %(<meta property="og:title" content="#{escaped_title}" />)
+      )
+    end
+
+    description = DescriptionSource.description(doc)
+    next if description.to_s.empty?
+
+    escaped_description =
+      CGI.escapeHTML(DescriptionSource.plain_text(description))
+
+    doc.output = doc.output.sub(
+      /<meta name="description" content="[^"]*" \/>/,
+      %(<meta name="description" content="#{escaped_description}" />)
+    )
+    doc.output = doc.output.sub(
+      /<meta property="og:description" content="[^"]*" \/>/,
+      %(<meta property="og:description" content="#{escaped_description}" />)
+    )
+  end
+end

--- a/_plugins/section_generator.rb
+++ b/_plugins/section_generator.rb
@@ -2,6 +2,22 @@ module Jekyll
   HEAD = '_head.md'
   TRAILER = '_trailer.md'
 
+  module MarkdownSource
+    module_function
+
+    def read_with_front_matter(path)
+      text = File.read(path)
+      data = {}
+
+      if text =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+        data = SafeYAML.load(Regexp.last_match(1)) || {}
+        text = Regexp.last_match.post_match
+      end
+
+      [data, text]
+    end
+  end
+
   class Section < Page
     def initialize(site, collection)
       @site = site
@@ -15,13 +31,19 @@ module Jekyll
       self.data['section_label'] = collection
       collections_config = site.config['collections'] || {}
       section_config = collections_config[collection] || {}
+      if self.data['title'].to_s.empty? && section_config['title']
+        self.data['title'] = section_config['title']
+        self.data['section_fallback_title'] = true
+      end
+      self.data['description'] = section_config['description']
       self.data['section_sort_reversed'] = section_config['sort_reversed']
       self.data['section_overview_page'] = section_config['overview_page']
       if section.entries.include? HEAD
-        tmpl = File.read File.join site.source, '_' + collection, HEAD
-        tmpl = (Liquid::Template.parse tmpl).render site.site_payload
+        head_data, head_body = MarkdownSource.read_with_front_matter(File.join(site.source, '_' + collection, HEAD))
+        tmpl = (Liquid::Template.parse head_body).render site.site_payload
         html = Kramdown::Document.new(tmpl).to_html
         self.data['head'] = html
+        self.data['description'] = head_data['description'] if head_data['description']
       end
       if section.entries.include? TRAILER
         tmpl = File.read File.join site.source, '_' + collection, TRAILER

--- a/index.html
+++ b/index.html
@@ -1,13 +1,14 @@
 ---
 layout: basic
 headline: Welcome to Squeak<span class="hidden-xs">/Smalltalk</span>
-welcome: >
+welcome: &welcome >
   Squeak is a modern, open-source Smalltalk programming system with fast execution
   environments for all major platforms. It features the Morphic framework,
   which promotes low effort graphical, interactive application development and
   maintenance. Many projects have been successfully created with Squeak. They
   cover a wide range of domains such as education, multimedia, gaming, research,
   and commerce.
+description: *welcome
 
 download_link_mac: https://files.squeak.org/6.0/Squeak6.0-22148-64bit/Squeak6.0-22148-64bit-202312181441-macOS.dmg
 download_link_win: https://files.squeak.org/6.0/Squeak6.0-22148-64bit/Squeak6.0-22148-64bit-202312181441-Windows-x64.zip


### PR DESCRIPTION
Previously, these looked very generic for most pages (essentially showing the same text for almost all pages, and just repeating the title twice for release notes). Now they look much more precise. :-)

- If no title is available from the page config, fall back to the title in the section config (global collection) (analogously to how <title> tag is already computed)
- Descriptions can be be specified in the section config or in the frontmatter of pages
- If no description is specified, generate one instead from the first meaningful paragraph of the page
- Fix section generator to properly parse frontmatter from _head.md instead outputting it verbatim

<img width="346" height="88" alt="image" src="https://github.com/user-attachments/assets/ba85ce2c-3bb9-41e5-a9d3-2eaefdee3d76" />
<img width="346" height="88" alt="image" src="https://github.com/user-attachments/assets/0888bbf5-8d7f-487f-8234-ba4c101304d7" />
<img width="346" height="88" alt="image" src="https://github.com/user-attachments/assets/2c08ac4a-8649-471c-804f-ddc4f7905d07" />
<img width="346" height="88" alt="image" src="https://github.com/user-attachments/assets/2355c7bf-c0f3-4088-9d37-5739ce35d520" />

 \(<https://socialsharepreview.com/>\)